### PR TITLE
Added functionality to GET comments by post_id

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -2,7 +2,14 @@ import json
 from http.server import HTTPServer
 from handler import HandleRequests, status
 
-from views import login_user, create_user, get_categories, create_category, get_posts
+from views import (
+    login_user,
+    create_user,
+    get_categories,
+    create_category,
+    get_posts,
+    create_comment,
+)
 
 
 class JSONServer(HandleRequests):
@@ -25,6 +32,10 @@ class JSONServer(HandleRequests):
                     return self.response(
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
+
+        # if url["request_resource"] == "comments":
+        #     if pk == 0:
+        #         successfully_posted = create_comment()
 
         elif url["requested_resource"] == "categories":
             if pk == 0:

--- a/json-server.py
+++ b/json-server.py
@@ -2,14 +2,10 @@ import json
 from http.server import HTTPServer
 from handler import HandleRequests, status
 
-from views import (
-    login_user,
-    create_user,
-    get_categories,
-    create_category,
-    get_posts,
-    create_comment,
-)
+from views import login_user, create_user
+from views import get_categories, create_category
+from views import get_posts
+from views import get_comments_by_post_id
 
 
 class JSONServer(HandleRequests):
@@ -32,10 +28,6 @@ class JSONServer(HandleRequests):
                     return self.response(
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
-
-        # if url["request_resource"] == "comments":
-        #     if pk == 0:
-        #         successfully_posted = create_comment()
 
         elif url["requested_resource"] == "categories":
             if pk == 0:
@@ -60,6 +52,10 @@ class JSONServer(HandleRequests):
 
         elif url["requested_resource"] == "categories":
             response_body = get_categories()
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        elif url["requested_resource"] == "comments":
+            response_body = get_comments_by_post_id(url)
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         else:

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -93,3 +93,7 @@ INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.c
 
 INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date', 'image_url', 'content', 'approved')
 VALUES (1, 1, "This is a title", "2024-03-04 15:14:13.180700", null, "This is the body of the post", 1)
+
+
+INSERT INTO Comments ('post_id', 'author_id', 'content')
+VALUES (1, 1, "This is such a funny comment!")

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -92,8 +92,14 @@ INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.c
 
 
 INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date', 'image_url', 'content', 'approved')
-VALUES (1, 1, "This is a title", "2024-03-04 15:14:13.180700", null, "This is the body of the post", 1)
+VALUES (1, 1, "This is a title", "2024-03-04 15:14:13.180700", null, "This is the body of the post", 1);
 
 
 INSERT INTO Comments ('post_id', 'author_id', 'content')
-VALUES (1, 1, "This is such a funny comment!")
+VALUES (1, 1, "This is such a funny comment!");
+
+INSERT INTO Comments ('post_id', 'author_id', 'content')
+VALUES (2, 2, "BLAH BLAH BLAH");
+
+INSERT INTO Comments ('post_id', 'author_id', 'content')
+VALUES (1, 1, "test test test");

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,3 +1,4 @@
 from .user import login_user, create_user
 from .post import get_posts
 from .categories import get_categories, create_category
+from .comment import create_comment

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .user import login_user, create_user
 from .post import get_posts
 from .categories import get_categories, create_category
-from .comment import create_comment
+from .comment import get_comments_by_post_id

--- a/views/comment.py
+++ b/views/comment.py
@@ -1,0 +1,65 @@
+import sqlite3
+import json
+
+
+# def create_comment(post, user):
+#     with sqlite3.connect("./db.sqlite3") as conn:
+#         conn.row_factory = sqlite3.Row
+#         db_cursor = conn.cursor()
+
+#         db_cursor.execute(
+#             """
+#                 INSERT INTO Comments
+#                     (
+#                         post_id,
+#                         author_id,
+#                         content
+#                     )
+#                         VALUES
+#                     (
+#                         ?,
+#                         ?,
+#                         ?
+#                     )
+#             """,
+#             (
+#                 post["id"],
+#                 user["id"],
+#                 "COMMENT DATA",
+#             ),  # HOW DO I GET THIS??
+#         )
+
+
+# post_id
+# author_id
+# content
+
+
+def get_comments_by_post_id(post_id):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                SELECT
+                    c.id,
+                    c.post_id,
+                    p.id
+                    u.user_id,
+                    u.image_url,
+                    c.author_id,
+                    c.content
+                FROM Comments c
+                    JOIN Users u ON u.id = c.author_id
+                    JOIN Posts p ON p.id = c.post_id
+    """
+        )
+
+
+# id
+# post_id
+# ---- user_id
+# ---- image_url
+# author_id
+# content

--- a/views/comment.py
+++ b/views/comment.py
@@ -2,63 +2,51 @@ import sqlite3
 import json
 
 
-# def create_comment(post, user):
-#     with sqlite3.connect("./db.sqlite3") as conn:
-#         conn.row_factory = sqlite3.Row
-#         db_cursor = conn.cursor()
-
-#         db_cursor.execute(
-#             """
-#                 INSERT INTO Comments
-#                     (
-#                         post_id,
-#                         author_id,
-#                         content
-#                     )
-#                         VALUES
-#                     (
-#                         ?,
-#                         ?,
-#                         ?
-#                     )
-#             """,
-#             (
-#                 post["id"],
-#                 user["id"],
-#                 "COMMENT DATA",
-#             ),  # HOW DO I GET THIS??
-#         )
-
-
-# post_id
-# author_id
-# content
-
-
-def get_comments_by_post_id(post_id):
+def get_comments_by_post_id(url):
     with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        db_cursor.execute(
-            """
-                SELECT
-                    c.id,
-                    c.post_id,
-                    p.id
-                    u.user_id,
-                    u.image_url,
-                    c.author_id,
-                    c.content
-                FROM Comments c
-                    JOIN Users u ON u.id = c.author_id
-                    JOIN Posts p ON p.id = c.post_id
-    """
-        )
+        if "_post_id" in url["query_params"]:
+            db_cursor.execute(
+                """
+                    SELECT
+                        c.id,
+                        c.post_id,
+                        p.id,
+                        u.id AS user_id,
+                        u.profile_image_url,
+                        c.author_id,
+                        c.content
+                    FROM Comments c
+                        JOIN Users u ON u.id = c.author_id
+                        JOIN Posts p ON p.id = c.post_id
+                    WHERE c.post_id = ?
+        """,
+                (url["query_params"]["_post_id"][0],),
+            )
+            query_results = db_cursor.fetchall()
+
+            comments = []
+            for row in query_results:
+                post = {
+                    "user_id": row["user_id"],
+                    "profile_image_url": row["profile_image_url"],
+                }
+                comment = {
+                    "id": row["id"],
+                    "post": post,
+                    "author_id": row["author_id"],
+                    "content": row["content"],
+                }
+                comments.append(comment)
+
+            return json.dumps(comments)
 
 
 # id
 # post_id
+# ---- POST:
 # ---- user_id
 # ---- image_url
 # author_id


### PR DESCRIPTION
This PR is in reference to Ticket #27.
Peer testing is needed to check the functionality of the do_GET get_comments_by_user_id() function

Instructions for testing:
1. `git fetch --all`
2. switch branches to `comments/get_comments/api`
3. open postman
4. GET request's to test:
- `http://localhost:9999/comments?_post_id=1` should return 200 Success
- `http://localhost:9999/comments?_post_id=2` should return 200 Success
- `http://localhost:9999/comments?_post_id=3` (and higher)should return 404 Not found

Request Body example:
```
[
    {
        "id": 2,
        "post_id": 2,
        "author_id": 2,
        "author": {
            "user_id": 2,
            "first_name": "tom",
            "last_name": "timmy",
            "username": "NSS_user_2"
        },
        "content": "BLAH BLAH BLAH"
    }
]
```