### PR TITLE
Added Create Comment Functionality for backend

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -54,6 +54,20 @@ class JSONServer(HandleRequests):
                         "Error creating tag: Invalid data format. Need a label",
                         status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                     )
+
+        elif url["requested_resource"] == "comments":
+            if pk == 0:
+                try:
+                    successfully_posted = create_comment(request_body)
+                    if successfully_posted:
+                        return self.response("", status.HTTP_201_SUCCESS_CREATED.value)
+
+                except KeyError:
+                    return self.response(
+                        "Error creating comment: Need comment content",
+                        status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
+                    )
+
         else:
             return self.response(
                 "Requested resource not found",

--- a/json-server.py
+++ b/json-server.py
@@ -40,6 +40,11 @@ class JSONServer(HandleRequests):
                     return self.response(
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
+
+        # elif url["request_resource"] == "comments":
+        #     if pk == 0:
+        #         successfully_posted = create_comment()
+
         else:
             return self.response("", status.HTTP_500_SERVER_ERROR.value)
 

--- a/json-server.py
+++ b/json-server.py
@@ -41,11 +41,12 @@ class JSONServer(HandleRequests):
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
 
-        elif url["request_resource"] == "comments":
+        elif url["requested_resource"] == "comments":
             if pk == 0:
                 successfully_posted = create_comment(request_body)
                 if successfully_posted:
                     return self.response("", status.HTTP_201_SUCCESS_CREATED.value)
+
                 else:
                     return self.response(
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value

--- a/json-server.py
+++ b/json-server.py
@@ -5,7 +5,7 @@ from handler import HandleRequests, status
 from views import login_user, create_user
 from views import get_categories, create_category
 from views import get_posts, get_posts_by_user, retrieve_post
-from views import get_comments_by_post_id
+from views import get_comments_by_post_id, create_comment
 
 
 class JSONServer(HandleRequests):
@@ -41,9 +41,15 @@ class JSONServer(HandleRequests):
                         "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                     )
 
-        # elif url["request_resource"] == "comments":
-        #     if pk == 0:
-        #         successfully_posted = create_comment()
+        elif url["request_resource"] == "comments":
+            if pk == 0:
+                successfully_posted = create_comment(request_body)
+                if successfully_posted:
+                    return self.response("", status.HTTP_201_SUCCESS_CREATED.value)
+                else:
+                    return self.response(
+                        "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
+                    )
 
         else:
             return self.response("", status.HTTP_500_SERVER_ERROR.value)

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -247,3 +247,10 @@ VALUES (
   );
 
   UPDATE Users SET id = 3 WHERE first_name = "tim";
+
+  INSERT INTO "Comments" ("post_id", "author_id", "content")
+  VALUES (1, 1, "This is such a funny comment!");
+  INSERT INTO "Comments" ("post_id", "author_id", "content")
+  VALUES (2, 2, "BLAH BLAH BLAH");
+  INSERT INTO "Comments" ("post_id", "author_id", "content")
+  VALUES (1, 1, "test test test");

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .user import login_user, create_user
 from .post import get_posts_by_user, retrieve_post, get_posts
 from .categories import get_categories, create_category
-from .comment import get_comments_by_post_id
+from .comment import get_comments_by_post_id, create_comment

--- a/views/comment.py
+++ b/views/comment.py
@@ -7,8 +7,6 @@ def get_comments_by_post_id(url):
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        print(url["query_params"]["_post_id"][0])
-
         if "_post_id" in url["query_params"]:
             db_cursor.execute(
                 """
@@ -47,3 +45,33 @@ def get_comments_by_post_id(url):
                 comments.append(comment)
 
             return json.dumps(comments)
+
+
+def create_comment(comment_data):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                INSERT INTO Comments
+                    (
+                        post_id,
+                        author_id,
+                        content
+                    )
+                        VALUES
+                    (
+                        ?,
+                        ?,
+                        ?
+                    )
+            """,
+            (
+                comment_data["post_id"],
+                comment_data["author_id"],
+                comment_data["content"],
+            ),
+        )
+
+        return True if db_cursor.rowcount > 0 else False


### PR DESCRIPTION
This PR is in reference to #7.
Peer testing is required.
Please check the functionality of do_POST create_comment().

Instructions for testing:
1. `git fetch --all`
2. switch branches to `comments/create_comment/api`
3. open postman
4. perform a POST request to `http://localhost:9999/comments` with data like this:
```{
    "post_id": 1,
    "author_id": 1,
    "content": "4comment text goes here"
}```
5. the new data should post to the SQLite3 database