### PR TITLE
Added (backend) functionality to GET users

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -2,7 +2,7 @@ import json
 from http.server import HTTPServer
 from handler import HandleRequests, status
 
-from views import login_user, create_user
+from views import login_user, create_user, get_users
 from views import get_categories, create_category
 from views import get_posts, get_posts_by_user, retrieve_post, delete_post, create_post
 from views import get_comments_by_post_id, create_comment
@@ -107,6 +107,10 @@ class JSONServer(HandleRequests):
 
         elif url["requested_resource"] == "comments":
             response_body = get_comments_by_post_id(url)
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        elif url["requested_resource"] == "users":
+            response_body = get_users()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         else:

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
-from .user import login_user, create_user
+from .user import login_user, create_user, get_users
 from .post import get_posts_by_user, retrieve_post, get_posts, delete_post, create_post
 from .categories import get_categories, create_category
 from .comment import get_comments_by_post_id, create_comment

--- a/views/user.py
+++ b/views/user.py
@@ -68,3 +68,33 @@ def create_user(user):
         id = db_cursor.lastrowid
 
         return json.dumps({"token": id, "valid": True})
+
+
+def get_users():
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                SELECT 
+                    u.id,
+                    u.first_name,
+                    u.last_name,
+                    u.email,
+                    u.bio,
+                    u.username,
+                    u.password,
+                    u.profile_image_url,
+                    u.created_on,
+                    u.active
+                FROM Users u
+            """
+        )
+        query_results = db_cursor.fetchall()
+
+        users = []
+        for row in query_results:
+            users.append(dict(row))
+
+        return json.dumps(users)


### PR DESCRIPTION
This PR is in reference to Ticket #3 
Peer testing is needed to check the functionality of do_GET for get_users()

Instructions for testing:
1. `git fetch --all`
2. switch branches to `users/get_user/api`
3. open postman
4. GET request to test: `http://localhost:9999/users`

Request Body example:

```
[
    {
        "id": 1,
        "first_name": "Eric",
        "last_name": "Heidel",
        "email": "email@email.com",
        "bio": "Hello World!",
        "username": "NSS_user_1",
        "password": "12345",
        "profile_image_url": null,
        "created_on": "2024-03-04 15:14:13.180700",
        "active": 1
    },
    {
        "id": 2,
        "first_name": "tom",
        "last_name": "timmy",
        "email": "email1@email.com",
        "bio": "Hello World!",
        "username": "NSS_user_2",
        "password": "1234522",
        "profile_image_url": null,
        "created_on": "2024-03-05 14:08:40.407942",
        "active": 1
    }
] ... etc ...
```