### PR TITLE
Added backend functionality to GET tags

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -6,7 +6,7 @@ from views import login_user, create_user, get_users
 from views import get_categories, create_category
 from views import get_posts, get_posts_by_user, retrieve_post, delete_post, create_post
 from views import get_comments_by_post_id, create_comment
-from views import create_tag
+from views import create_tag, get_tags
 
 
 class JSONServer(HandleRequests):
@@ -111,6 +111,10 @@ class JSONServer(HandleRequests):
 
         elif url["requested_resource"] == "users":
             response_body = get_users()
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        elif url["requested_resource"] == "tags":
+            response_body = get_tags()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         else:

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -2,4 +2,4 @@ from .user import login_user, create_user, get_users
 from .post import get_posts_by_user, retrieve_post, get_posts, delete_post, create_post
 from .categories import get_categories, create_category
 from .comment import get_comments_by_post_id, create_comment
-from .tags import create_tag
+from .tags import create_tag, get_tags

--- a/views/tags.py
+++ b/views/tags.py
@@ -17,3 +17,25 @@ def create_tag(tag):
         new_tag_id = db_cursor.rowcount
 
     return True if new_tag_id > 0 else False
+
+
+def get_tags():
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                SELECT 
+                    t.id,
+                    t.label
+                FROM Tags t
+            """
+        )
+        query_results = db_cursor.fetchall()
+
+        tags = []
+        for row in query_results:
+            tags.append(dict(row))
+
+        return json.dumps(tags)


### PR DESCRIPTION
This PR is in reference to Ticket #26 
Peer testing is needed to check the functionality of the do_GET get_tags() function
Instructions for testing 

1. `git fetch --all`
2. `git checkout tags/get_tags/api`
3. open postman
4. GET request `http://localhost:9999/tags`

Intended example result:
```
[
    {
        "id": 1,
        "label": "JavaScript"
    },
    {
        "id": 2,
        "label": "Topical"
    },
    {
        "id": 3,
        "label": "News"
    }
]
```