### PR TITLE
Fixed get_user_by_token() to return a dictionary

### DIFF
--- a/views/user.py
+++ b/views/user.py
@@ -124,13 +124,9 @@ def get_user_by_token(pk):
             """,
             (pk,),
         )
-        query_results = db_cursor.fetchall()
+        query_results = db_cursor.fetchone()
 
-        users = []
-        for row in query_results:
-            users.append(dict(row))
-
-        return json.dumps(users)
+        return json.dumps(dict(query_results))
 
 
 def get_user_by_email(email):


### PR DESCRIPTION
as per the original PR:

1. `git fetch --all`
2. switch to this branch ~`saygin-getpostbytoken`~ `heidel/do_GET/get_user_by_token/fix/api`
3. open postman
4. perform a GET request to http://localhost:9999/users/1
5. ~check to see if correct information is returned~
6. the response body should be 1 dictionary, not a list with 1 dictionary within