### PR TITLE
Added backend functionality to DELETE categories

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -9,7 +9,7 @@ from views import (
     get_user_by_token,
     get_user_by_email,
 )
-from views import get_categories, create_category
+from views import get_categories, create_category, delete_category
 from views import (
     get_posts,
     get_posts_by_user,
@@ -181,6 +181,20 @@ class JSONServer(HandleRequests):
                 if successfully_deleted:
                     return self.response(
                         "", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value
+                    )
+
+                return self.response(
+                    "Requested resource not found",
+                    status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+                )
+
+        elif url["requested_resource"] == "categories":
+            if pk != 0:
+                successfully_deleted = delete_category(pk)
+                if successfully_deleted:
+                    return self.response(
+                        "",
+                        status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value,
                     )
 
                 return self.response(

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -13,6 +13,6 @@ from .post import (
     create_post,
     edit_post,
 )
-from .categories import get_categories, create_category
+from .categories import get_categories, create_category, delete_category
 from .comment import get_comments_by_post_id, create_comment
 from .tags import create_tag, add_tags_to_post, get_tags

--- a/views/categories.py
+++ b/views/categories.py
@@ -44,3 +44,16 @@ def create_category(category_data):
         rows_affected = db_cursor.rowcount
 
     return True if rows_affected > 0 else False
+
+
+def delete_category(pk):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                DELETE FROM Categories WHERE id = ?
+            """,
+            (pk,),
+        )
+        return True if db_cursor.rowcount > 0 else False


### PR DESCRIPTION
Peer testing is needed to check the functionality of the do_DELETE delete_category() function

Testing:
1. `git fetch --all`
2. `git checkout heidel/categories/delete-a-category/api`
3. postman GET request `http://localhost:9999/categories/**id-of-category**`
4. categories dict/entry in the database should be removed