### PR TITLE
fixed return on create post to return new post id

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -88,7 +88,7 @@ class JSONServer(HandleRequests):
             if pk == 0:
                 successfully_posted = create_post(request_body)
                 if successfully_posted:
-                    return self.response("", status.HTTP_201_SUCCESS_CREATED.value)
+                    return self.response(successfully_posted, status.HTTP_201_SUCCESS_CREATED.value)
 
                 else:
                     return self.response(

--- a/views/post.py
+++ b/views/post.py
@@ -30,9 +30,13 @@ def create_post(post):
             ),
         )
 
-        rows_affected = db_cursor.rowcount
+        # rows_affected = db_cursor.rowcount
 
-    return True if rows_affected > 0 else False
+        # return True if rows_affected > 0 else False
+
+        new_post_id = db_cursor.lastrowid
+
+        return json.dumps({"id": new_post_id, "valid": True})
 
 
 def retrieve_post(pk):
@@ -99,7 +103,7 @@ def retrieve_post(pk):
             }
             serialized_post = json.dumps(post)
         else:
-            serialized_post = json.dumps({})  
+            serialized_post = json.dumps({})
 
     return serialized_post
 


### PR DESCRIPTION
In order to navigate to the newly created post on the front end, I needed to edit the return in create_post. This PR references  a ticket in the client side. Link to client side ticket: https://github.com/NSS-Day-Cohort-68/rare-client-rare-team3/issues/40

To test changes:
1. `git fetch --all` 
2. switch to this branch `Posts/create_post/returnID_fix/api`
3. make sure the api is running
4. open postman
5. Send a POST fetch to `http://localhost:9999/posts` with the following body: 

```
{    
    "user_id": 2,
    "category_id": 1,
    "title": "The Art of Culinary Delights",
    "publication_date": null,
    "image_url": null,
    "content": "Indulge your senses in the world of culinary wonders. From mouth-watering recipes to gastronomic adventures, join us on a gastronomical journey like no other."
} 
```

6. Response in postman should be similar to this:
```
{
    "id": 24,
    "valid": true
}
```
7. Verify in your database that the new post is in your database.