### PR TITLE
Added backend functionality to DELETE tags

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -19,7 +19,7 @@ from views import (
     edit_post,
 )
 from views import get_comments_by_post_id, create_comment
-from views import create_tag, add_tags_to_post, get_tags
+from views import create_tag, add_tags_to_post, get_tags, delete_tag
 
 
 class JSONServer(HandleRequests):
@@ -88,7 +88,9 @@ class JSONServer(HandleRequests):
             if pk == 0:
                 successfully_posted = create_post(request_body)
                 if successfully_posted:
-                    return self.response(successfully_posted, status.HTTP_201_SUCCESS_CREATED.value)
+                    return self.response(
+                        successfully_posted, status.HTTP_201_SUCCESS_CREATED.value
+                    )
 
                 else:
                     return self.response(
@@ -195,6 +197,19 @@ class JSONServer(HandleRequests):
                     return self.response(
                         "",
                         status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value,
+                    )
+
+                return self.response(
+                    "Requested resource not found",
+                    status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+                )
+
+        elif url["requested_resource"] == "tags":
+            if pk != 0:
+                successfully_deleted = delete_tag(pk)
+                if successfully_deleted:
+                    return self.response(
+                        "", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value
                     )
 
                 return self.response(

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -15,4 +15,4 @@ from .post import (
 )
 from .categories import get_categories, create_category, delete_category, edit_category
 from .comment import get_comments_by_post_id, create_comment
-from .tags import create_tag, add_tags_to_post, get_tags
+from .tags import create_tag, add_tags_to_post, get_tags, delete_tag

--- a/views/tags.py
+++ b/views/tags.py
@@ -61,7 +61,7 @@ def get_tags():
 
 
 def delete_tag(pk):
-    with sqlite3.connect("./db/sqlite3") as conn:
+    with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 

--- a/views/tags.py
+++ b/views/tags.py
@@ -58,3 +58,17 @@ def get_tags():
             tags.append(dict(row))
 
         return json.dumps(tags)
+
+
+def delete_tag(pk):
+    with sqlite3.connect("./db/sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+                DELETE FROM Tags WHERE id = ?
+            """,
+            (pk,),
+        )
+        return True if db_cursor.rowcount > 0 else False


### PR DESCRIPTION
I have added backend support to delete a tag from the database.

Peer testing is needed to check the functionality of the do_DELETE delete_tag() function

Testing:
1. `git fetch`
2. `git checkout heidel/tags/delete-a-tag/api`
3. open postman
4. DELETE request `http://localhost:9999/tags/**id-of-tag-in-database**`

after the request, confirm that the tag information has been deleted from the database