### PR TITLE
Added GET functionality in backend to get PostTags by post_id

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -19,7 +19,14 @@ from views import (
     edit_post,
 )
 from views import get_comments_by_post_id, create_comment
-from views import create_tag, add_tags_to_post, get_tags, delete_tag, edit_tag
+from views import (
+    create_tag,
+    add_tags_to_post,
+    get_tags,
+    delete_tag,
+    edit_tag,
+    get_tags_by_post,
+)
 
 
 class JSONServer(HandleRequests):
@@ -165,6 +172,12 @@ class JSONServer(HandleRequests):
         elif url["requested_resource"] == "tags":
             response_body = get_tags()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        elif url["requested_resource"] == "post_tags":
+            if "post_id" in url.get("query_params"):
+                post_id = int(url["query_params"]["post_id"][0])
+                tags_by_post = get_tags_by_post(post_id)
+                return self.response(tags_by_post, status.HTTP_200_SUCCESS.value)
 
         else:
             return self.response(

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -15,4 +15,11 @@ from .post import (
 )
 from .categories import get_categories, create_category, delete_category, edit_category
 from .comment import get_comments_by_post_id, create_comment
-from .tags import create_tag, add_tags_to_post, get_tags, delete_tag, edit_tag
+from .tags import (
+    create_tag,
+    add_tags_to_post,
+    get_tags,
+    delete_tag,
+    edit_tag,
+    get_tags_by_post
+)

--- a/views/tags.py
+++ b/views/tags.py
@@ -93,3 +93,48 @@ def edit_tag(pk, tag_data):
         )
 
         return True if db_cursor.rowcount > 0 else False
+
+
+def get_tags_by_post(postId):
+    # Open connection with the database
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        # Write the SQL query to get postTags by post id
+        db_cursor.execute(
+            """
+            SELECT
+                pt.id,
+                pt.post_id,
+                pt.tag_id,
+                t.label
+            FROM PostTags pt
+            JOIN Tags t ON pt.tag_id = t.id
+            WHERE pt.post_id = ?
+            """,
+            (postId,),
+        )
+
+        query_results = db_cursor.fetchall()
+
+        # Initialize an empty list and then add each dictionary to it
+        postTags = []
+
+        for row in query_results:
+
+            tag = {"label": row["label"]}
+
+            post_tag = {
+                "id": row["id"],
+                "post_id": row["post_id"],
+                "tag_id": row["tag_id"],
+                "tag": tag,
+            }
+
+            postTags.append(post_tag)
+
+        # Serialize Python list to JSON encoded string
+        serialized_posts = json.dumps(postTags)
+
+        return serialized_posts


### PR DESCRIPTION
In order to view the tags related to a post in the client side post details view, I had to add get functionality in the backend. Link to client side ticket: https://github.com/NSS-Day-Cohort-68/rare-client-rare-team3/issues/39

To test:
1. `git fetch --all` 
2. switch to this branch `stacy/tags/get_post_tags/api`
3. Make sure you have PostTags in your database
4. If you do not have any PostTags, you can use these inserts to add some:
```
  INSERT INTO PostTags ("post_id", "tag_id")
  VALUES (1, 1);

  INSERT INTO PostTags ("post_id", "tag_id")
  VALUES (1, 2);
```
6. make sure the api is running
7. open postman
8. Send a GET to `http://localhost:9999/post_tags?post_id=1` 
9. Response in postman should be similar to this:
```
[
    {
        "id": 4,
        "post_id": 1,
        "tag_id": 1,
        "tag": {
            "label": "JavaScript"
        }
    },
    {
        "id": 5,
        "post_id": 1,
        "tag_id": 3,
        "tag": {
            "label": "HTML"
        }
    },
    {
        "id": 9,
        "post_id": 1,
        "tag_id": 2,
        "tag": {
            "label": "CSS"
        }
    }
]

```