### PR TITLE
Datetime.now() criteria has been added to to create_comment()

### DIFF
--- a/views/comment.py
+++ b/views/comment.py
@@ -1,5 +1,6 @@
 import sqlite3
 import json
+from datetime import datetime
 
 
 def get_comments_by_post_id(url):
@@ -58,10 +59,12 @@ def create_comment(comment_data):
                     (
                         post_id,
                         author_id,
-                        content
+                        content,
+                        creation_date
                     )
                         VALUES
                     (
+                        ?,
                         ?,
                         ?,
                         ?
@@ -71,6 +74,7 @@ def create_comment(comment_data):
                 comment_data["post_id"],
                 comment_data["author_id"],
                 comment_data["content"],
+                datetime.now(),
             ),
         )
 

--- a/views/comment.py
+++ b/views/comment.py
@@ -60,7 +60,7 @@ def create_comment(comment_data):
                         post_id,
                         author_id,
                         content,
-                        creation_date
+                        creation_datetime
                     )
                         VALUES
                     (


### PR DESCRIPTION
I have added support for create_comment() to include the creation_datetime criteria into the database.

Testing:

1. `git fetch`
2. `git checkout heidel/comments/create-a-comment/api`
3. open postman
4. request url `http://localhost:9999/comments`
5. example request body:
```
{
    "post_id": #,
     (this integer needs to the
       id of an existing post in your database)
    "author_id": #,
     (this integer needs to be the
       id of a user in your database)
    "content": "TEST COMMENT"
}
```

6. confirm that the comment dict is posted to your database and that the dict has a valid entry for the column "creation_datetime"